### PR TITLE
Update Jenkins version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/jenkins-role/tree/develop)
 
+### Changed
+- *Jenkins default version 2.138.1* @jnogol
+- *Install jdk-tool plugin by default* @jnogol
+
 ## [2.0.1](https://github.com/idealista/jenkins-role/tree/2.0.1)
 ## [Full Changelog](https://github.com/idealista/jenkins-role/compare/2.0.0...2.0.1)
 ### Fixed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ## General
-jenkins_version: "2.107.3"
+jenkins_version: "2.138.1"
 
 ## Service options
 # Owner
@@ -75,7 +75,8 @@ jenkins_ldap_enabled: false
 
 # Other plugins could be found in:
 # https://plugins.jenkins.io/
-jenkins_plugins: []
+jenkins_plugins:
+  - { name: "jdk-tool", version: "1.1"} # This one is needed since Jenkins v2.112
 
 ## SETTINGS
 jenkins_settings_java: []

--- a/tests/group_vars/jenkins_vagrant.yml
+++ b/tests/group_vars/jenkins_vagrant.yml
@@ -36,6 +36,7 @@ jenkins_plugins:
   - { name: "bouncycastle-api", version: "2.16.2"}
   - { name: "command-launcher", version: "1.2"}
   - { name: "msbuild", version: "1.29"}
+  - { name: "jdk-tool", version: "1.1"}
 
 jenkins_script_parameters:
   NodeJS:


### PR DESCRIPTION
Due to the https://jenkins.io/changelog/#v2.112 `Install from java.sun.com installation method for JDK tools has been moved to a new JDK Tool Plugin. (issue 22367)`, `jdk-tool` plugin is installed by default.

