### PR TITLE
25: Variable for seed job file is created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 .cache/
 tests/__pycache__/
 tests/playbook.retry
+
+#IDE
+.project
+.classpath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/jenkins-role/tree/develop)
+### Changed
+- *Allow change dslJob.xml file via variable* @amanzanotejon
 
 ## [2.1.0](https://github.com/idealista/jenkins-role/tree/2.1.0)
 ## [Full Changelog](https://github.com/idealista/jenkins-role/compare/2.0.1...2.1.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,6 +115,7 @@ jenkins_seed_job_name: seed_job
 jenkins_seed_job_files_path: "{{ playbook_dir }}/files/seedJob/"
 jenkins_seed_job_templates_path: "{{ playbook_dir }}/templates/seedJob/"
 jenkins_seed_job_java_tag: java8-openjdk
+jenkins_seed_job_config_file: "templates/seedJob/dslJob.xml"
 
 # Misc
 jenkins_use_security: "false | {{ jenkins_ldap_enabled }} "

--- a/tasks/seed_job.yml
+++ b/tasks/seed_job.yml
@@ -2,7 +2,7 @@
 
 - name: Jenkins | Create seed Job
   jenkins_job:
-    config: "{{ lookup('template', 'seedJob/dslJob.xml') }}"
+    config: "{{ lookup('template', '{{ jenkins_seed_job_config_file }}') }}"
     name: "{{ jenkins_seed_job_name }}"
     user: "{{ jenkins_admin_username }}"
     password: "{{ jenkins_admin_password }}"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

A new variable is created: jenkins_seed_job_config_file_path.
It allows you to overwrite the seed_job

### Benefits

More flexible

### Possible Drawbacks

Any

### Applicable Issues


