### PR TITLE
Support for jenkins 2.249.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
   jobs:
     DOCKER_BASE_IMAGE=idealista/jdk:8u252-stretch-openjdk-headless
 
-
 script:
   - pipenv run molecule test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ install:
   - pip install pipenv
   - pipenv sync
 
+env:
+  jobs:
+    DOCKER_BASE_IMAGE=idealista/jdk:8u252-stretch-openjdk-headless
+
+
 script:
   - pipenv run molecule test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/jenkins_role/tree/develop)
+### Added
+- *[#48] Support for jenkins v2.249.2.* @vicsufer
+- *[#48] Add session cookie for API Requests* @vicsufer
+### Changed
+- *[#48] Disable CLI with java argument-* @vicsufer
 
 ## [2.4.0](https://github.com/idealista/jenkins_role/tree/2.4.0)
 ## [Full Changelog](https://github.com/idealista/jenkins_role/compare/2.3.0...2.4.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 - *[#48] Support for jenkins v2.249.2.* @vicsufer
 - *[#48] Add session cookie for API Requests* @vicsufer
 ### Changed
-- *[#48] Disable CLI with java argument-* @vicsufer
+- *[#48] Disable CLI with java argument instead of remote script call* @vicsufer
 
 
 ## [2.5.0](https://github.com/idealista/jenkins_role/tree/2.5.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ## General
-jenkins_version: "2.138.1"
+jenkins_version: "2.263"
 
 ## Service options
 # Owner

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ## General
-jenkins_version: "2.263"
+jenkins_version: "2.249.2"
 
 ## Service options
 # Owner

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ jenkins_java_xmx: "256m"
 jenkins_java_net_prefer_ipv4_stack: "true"
 jenkins_install_run_setup_wizard: "false"
 jenkins_diy_chunking: "false"  # https://issues.jenkins-ci.org/browse/JENKINS-23232
+jenkins_disable_cli: true
 
 jenkins_java_args:
   - "-Djava.awt.headless={{ jenkins_java_awt_headless }}"
@@ -43,6 +44,7 @@ jenkins_java_args:
   - "-Xmx{{ jenkins_java_xmx }}"
   - "-Djava.net.preferIPv4Stack={{ jenkins_java_net_prefer_ipv4_stack }}"
   - "-Djenkins.install.runSetupWizard={{ jenkins_install_run_setup_wizard }}"
+  - "-Djenkins.CLI.disabled=true"
   - "-Dhudson.diyChunking={{ jenkins_diy_chunking }}"
   - "-Dfile.encoding=UTF-8"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ jenkins_java_args:
   - "-Xmx{{ jenkins_java_xmx }}"
   - "-Djava.net.preferIPv4Stack={{ jenkins_java_net_prefer_ipv4_stack }}"
   - "-Djenkins.install.runSetupWizard={{ jenkins_install_run_setup_wizard }}"
-  - "-Djenkins.CLI.disabled=true"
+  - "-Djenkins.CLI.disabled={{jenkins_disable_cli}}"
   - "-Dhudson.diyChunking={{ jenkins_diy_chunking }}"
   - "-Dfile.encoding=UTF-8"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ jenkins_java_args:
   - "-Xmx{{ jenkins_java_xmx }}"
   - "-Djava.net.preferIPv4Stack={{ jenkins_java_net_prefer_ipv4_stack }}"
   - "-Djenkins.install.runSetupWizard={{ jenkins_install_run_setup_wizard }}"
-  - "-Djenkins.CLI.disabled={{jenkins_disable_cli}}"
+  - "-Djenkins.CLI.disabled={{ jenkins_disable_cli }}"
   - "-Dhudson.diyChunking={{ jenkins_diy_chunking }}"
   - "-Dfile.encoding=UTF-8"
 

--- a/files/security/DisableCli.groovy
+++ b/files/security/DisableCli.groovy
@@ -1,4 +1,0 @@
-#!groovy
-import jenkins.model.Jenkins
-
-Jenkins.instance.getDescriptor("jenkins.CLI").get().setEnabled(false)

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint:
 platforms:
   - name: jenkinsmaster
     hostname: jenkinsmaster
-    image: idealista/jdk:8u252-stretch-openjdk-headless
+    image: ${DOCKER_IMAGE_BASE:-idealista/jdk:8u252-stretch-openjdk-headless}
     privileged: True
     capabilities:
       - SYS_ADMIN
@@ -30,7 +30,7 @@ platforms:
 
   - name: jenkinsslave
     hostname: jenkinsslave
-    image: idealista/jdk:8u252-stretch-openjdk-headless
+    image: ${DOCKER_IMAGE_BASE:-idealista/jdk:8u252-stretch-openjdk-headless}
     privileged: True
     capabilities:
       - SYS_ADMIN

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,7 +4,7 @@
     - name: Jenkins Slave | PRE_TASKS | Install required libs
       apt:
         pkg: "{{ item }}"
-        state: installed
+        state: present
         update_cache: true
         cache_valid_time: 600
       loop:

--- a/tasks/script/quiet.yml
+++ b/tasks/script/quiet.yml
@@ -18,4 +18,5 @@
     status_code: 302
     headers:
       Jenkins-Crumb: "{{ crumb.content.split(':')[1] }}"
+      Cookie: "{{ crumb.cookies_string }}"
   when: item in ['quietDown', 'cancelQuietDown']

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -17,7 +17,7 @@
     url: "{{ jenkins_url }}"
   with_items:
     - ConfigureAgent
-  
+
 - name: Jenkins | Configure default users
   template:
     src: CreateInitialCredentials.groovy.j2

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -9,7 +9,7 @@
     args:
       crumb_enabled: "{{ jenkins_crumb_enabled | default(false) }}"
 
-- name: Jenkins | Configure Agent & CLI
+- name: Jenkins | Configure Agent
   jenkins_script:
     script: "{{ lookup('file', 'security/' + item + '.groovy') }}"
     user: "{{ jenkins_admin_username }}"
@@ -17,4 +17,4 @@
     url: "{{ jenkins_url }}"
   with_items:
     - ConfigureAgent
-    - DisableCli
+

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -17,4 +17,11 @@
     url: "{{ jenkins_url }}"
   with_items:
     - ConfigureAgent
-
+  
+- name: Jenkins | Configure default users
+  template:
+    src: CreateInitialCredentials.groovy.j2
+    dest: "{{ jenkins_init_scripts_path }}/CreateInitialCredentials.groovy"
+  when: jenkins_check.changed | bool
+  tags:
+    skip_ansible_lint

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -17,11 +17,3 @@
     url: "{{ jenkins_url }}"
   with_items:
     - ConfigureAgent
-
-- name: Jenkins | Configure default users
-  template:
-    src: CreateInitialCredentials.groovy.j2
-    dest: "{{ jenkins_init_scripts_path }}/CreateInitialCredentials.groovy"
-  when: jenkins_check.changed | bool
-  tags:
-    skip_ansible_lint

--- a/tasks/seed_job.yml
+++ b/tasks/seed_job.yml
@@ -36,17 +36,6 @@
       Content-Type: "text/xml"
   when: seed_job_exists.status != 200
 
-# - name: Jenkins | Create seed Job
-#   jenkins_job:
-#     config: "{{ lookup('template', '{{ jenkins_seed_job_config_file }}') }}"
-#     name: "{{ jenkins_seed_job_name }}"
-#     user: "{{ jenkins_admin_username }}"
-#     password: "{{ jenkins_admin_password }}"
-#     url: "{{ jenkins_url }}"
-#   headers:
-#       Jenkins-Crumb: "{{ crumb_seed.content.split(':')[1] }}"
-#       Cookie: "{{ crumb_seed.cookies_string }}"
-
 - name: Jenkins | Ensure workspace exists
   file:
     path: "{{ jenkins_home_path }}/jobs/{{ jenkins_seed_job_name }}/workspace"

--- a/tasks/seed_job.yml
+++ b/tasks/seed_job.yml
@@ -1,12 +1,50 @@
 ---
 
-- name: Jenkins | Create seed Job
-  jenkins_job:
-    config: "{{ lookup('template', '{{ jenkins_seed_job_config_file }}') }}"
-    name: "{{ jenkins_seed_job_name }}"
+- name: Jenkins | Generate crumb
+  uri:
+    url: "{{ jenkins_url }}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)"
     user: "{{ jenkins_admin_username }}"
     password: "{{ jenkins_admin_password }}"
-    url: "{{ jenkins_url }}"
+    force_basic_auth: yes
+    return_content: yes
+  register: crumb_seed
+
+- name: Jenkins | Check if seed job exists
+  uri:
+    url: "{{ jenkins_url }}/job/{{ jenkins_seed_job_name }}/api/json"
+    user: "{{ jenkins_admin_username }}"
+    password: "{{ jenkins_admin_password }}"
+    force_basic_auth: yes
+    headers:
+      Jenkins-Crumb: "{{ crumb_seed.content.split(':')[1] }}"
+      Cookie: "{{ crumb_seed.cookies_string }}"
+  register: seed_job_exists
+
+- name: Jenkins | Create seed job
+  uri:
+    url: "{{ jenkins_url }}/createItem?name={{ jenkins_seed_job_name }}"
+    method: POST
+    user: "{{ jenkins_admin_username }}"
+    password: "{{ jenkins_admin_password }}"
+    force_basic_auth: yes
+    body: "{{ lookup('template', '{{ jenkins_seed_job_config_file }}') }}"
+    status_code: 200
+    headers:
+      Jenkins-Crumb: "{{ crumb_seed.content.split(':')[1] }}"
+      Cookie: "{{ crumb_seed.cookies_string }}"
+      Content-Type: "text/xml"
+  when: seed_job_exists.status != 200
+
+# - name: Jenkins | Create seed Job
+#   jenkins_job:
+#     config: "{{ lookup('template', '{{ jenkins_seed_job_config_file }}') }}"
+#     name: "{{ jenkins_seed_job_name }}"
+#     user: "{{ jenkins_admin_username }}"
+#     password: "{{ jenkins_admin_password }}"
+#     url: "{{ jenkins_url }}"
+#   headers:
+#       Jenkins-Crumb: "{{ crumb_seed.content.split(':')[1] }}"
+#       Cookie: "{{ crumb_seed.cookies_string }}"
 
 - name: Jenkins | Ensure workspace exists
   file:
@@ -79,15 +117,6 @@
   with_items:
     - "{{ dsl_files_exist | difference(dsl_files) }}"
 
-- name: Jenkins | Generate crumb
-  uri:
-    url: "{{ jenkins_url }}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)"
-    user: "{{ jenkins_admin_username }}"
-    password: "{{ jenkins_admin_password }}"
-    force_basic_auth: yes
-    return_content: yes
-  register: crumb_seed
-
 - name: Jenkins | Build seed job
   uri:
     url: "{{ jenkins_url }}/job/{{ jenkins_seed_job_name }}/build"
@@ -98,3 +127,4 @@
     status_code: 201
     headers:
       Jenkins-Crumb: "{{ crumb_seed.content.split(':')[1] }}"
+      Cookie: "{{ crumb_seed.cookies_string }}"

--- a/tasks/seed_job.yml
+++ b/tasks/seed_job.yml
@@ -18,6 +18,7 @@
     headers:
       Jenkins-Crumb: "{{ crumb_seed.content.split(':')[1] }}"
       Cookie: "{{ crumb_seed.cookies_string }}"
+  ignore_errors: true
   register: seed_job_exists
 
 - name: Jenkins | Create seed job


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Change remote scripting to rest API calls.
Disable jenkinscli usage by means of java arguments since old version is not longer supported.

### Benefits
Support latest LTS version of jenkins
Increase CSRF secutiry.

### Possible Drawbacks
N/A

### Applicable Issues

close #48 
