### PR TITLE
Allow to override jenkins_archive vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,12 @@
 ## General
 jenkins_version: "2.249.3"
 
+# Jenkins package
+jenkins_repo_use_archive: true
+jenkins_repo_archive_url: "https://get.jenkins.io/debian/"
+jenkins_repo_archive_package_prefix: jenkins  # hudson or jenkins
+jenkins_repo_archive_package: "{{ jenkins_repo_archive_package_prefix }}_{{ jenkins_version }}_all.deb"
+
 ## Service options
 # Owner
 jenkins_user: jenkins

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 jenkins_version: "2.249.3"
 
 # Jenkins package
-jenkins_repo_use_archive: true
+jenkins_repo_use_archive: false
 jenkins_repo_archive_url: "https://get.jenkins.io/debian/"
 jenkins_repo_archive_package_prefix: jenkins  # hudson or jenkins
 jenkins_repo_archive_package: "{{ jenkins_repo_archive_package_prefix }}_{{ jenkins_version }}_all.deb"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,11 +15,6 @@ jenkins_repo_base_url: "https://pkg.jenkins.io/debian-stable"
 jenkins_repo_key_url: "{{ jenkins_repo_base_url }}/jenkins.io.key"
 jenkins_repo_url: "deb {{ jenkins_repo_base_url }}/ binary/"
 
-jenkins_repo_use_archive: false
-jenkins_repo_archive_url: "http://archives.jenkins-ci.org/debian"
-jenkins_repo_archive_package_prefix: jenkins  # hudson or jenkins
-jenkins_repo_archive_package: "{{ jenkins_repo_archive_package_prefix }}_{{ jenkins_version }}_all.deb"
-
 # URLs
 jenkins_url: "http://{{ jenkins_host }}:{{ jenkins_port }}"
 jenkins_plugins_update_url: https://updates.jenkins.io/update-center.json


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

We've experimented problems dealing with changing mirrors for jenkins archive repository thus we need to be able to override the jenkins archive related variables.

### Benefits

Protect playbooks against archive repository changes.

### Possible Drawbacks

N/A

### Applicable Issues

N/A
