### PR TITLE
[FEATURE] Add configuration from plugin download timeout

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -8,6 +8,10 @@
     url_password: "{{ jenkins_admin_password }}"
     url: "{{ jenkins_url }}"
     with_dependencies: true
+  register: plugin_result
+  until: plugin_result is success
+  retries: 10
+  delay: 5
   with_items:
     - "{{ jenkins_default_plugins }}"
     - "{{ jenkins_plugins }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,6 +10,8 @@ jenkins_required_libs:
   - python-jenkinsapi
   - python-lxml
   - fontconfig
+  - apt-utils
+  - default-jre
 
 
 # Package


### PR DESCRIPTION
<!--
PREREQUISITES

Have you read Idealista's Code of Conduct? By filling an Issue, you are expected to comply with it,
 including treating everyone with respect: https://github.com/idealista/idealista/blob/master/CODE_OF_CONDUCT.md

Check that your issue isn't already filled: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aidealista

Check that there is not already provided the described functionality
-->

### Description

Add configuration from plugin download timeout

### Why is this needed?

Poor connection quality or some issues in a server side could generate timeouts. 

### Additional Information

Configuration for timeout in jenkins_plugin: https://docs.ansible.com/ansible/latest/collections/community/general/jenkins_plugin_module.html#parameter-timeout