### PR TITLE
[FEATURE] Add configuration from plugin download timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: python
-python: "3.7"
+python: "3.9"
 
 sudo: required
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/jenkins_role/tree/develop)
 
+### Added
+- [#65](https://github.com/idealista/jenkins_role/issues/65) *[FEATURE] Add configuration from plugin download timeout* @ommarmol
+
 ## [2.8.0](https://github.com/idealista/jenkins_role/tree/2.8.0)
 ## [Full Changelog](https://github.com/idealista/jenkins_role/compare/2.7.0...2.8.0)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## [Unreleased](https://github.com/idealista/jenkins_role/tree/develop)
 
 ### Added
-- [#65](https://github.com/idealista/jenkins_role/issues/65) *[FEATURE] Add configuration from plugin download timeout* @ommarmol
+- [#65](https://github.com/idealista/jenkins_role/issues/65) *[FEATURE] Increase retry and delay parameters in plugin download configuration* @ommarmol
 
 ## [2.8.0](https://github.com/idealista/jenkins_role/tree/2.8.0)
 ## [Full Changelog](https://github.com/idealista/jenkins_role/compare/2.7.0...2.8.0)

--- a/Pipfile
+++ b/Pipfile
@@ -4,11 +4,11 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-molecule = "==3.0.4"
-ansible = "==2.8.8"
-docker = "==4.2.2"
+molecule = "==4.0.0"
+ansible = "==2.9.27"
+docker = "==5.0.0"
 
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+python_version = "3.9"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -8,6 +8,10 @@
     url_password: "{{ jenkins_admin_password }}"
     url: "{{ jenkins_url }}"
     with_dependencies: true
+  register: plugin_result
+  until: plugin_result is success
+  retries: 10
+  delay: 5
   with_items:
     - "{{ jenkins_default_plugins }}"
     - "{{ jenkins_plugins }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,8 +10,6 @@ jenkins_required_libs:
   - python-jenkinsapi
   - python-lxml
   - fontconfig
-  - apt-utils
-  - default-jre
 
 
 # Package

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,6 +10,8 @@ jenkins_required_libs:
   - python-jenkinsapi
   - python-lxml
   - fontconfig
+  - apt-utils
+  - default-jre
 
 
 # Package


### PR DESCRIPTION
<!--
PREREQUISITES

Have you read Idealista's Code of Conduct? By filling an Issue, you are expected to comply with it,
 including treating everyone with respect: https://github.com/idealista/idealista/blob/master/CODE_OF_CONDUCT.md

Check that your issue isn't already filled: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aidealista

Check that there is not already provided the described functionality
-->

### Description

Add configuration from plugin download timeout

### Why is this needed?

Poor connection quality or some issues in a server side could generate timeouts. 

### Additional Information

Configuration for timeout in jenkins_plugin: https://docs.ansible.com/ansible/latest/collections/community/general/jenkins_plugin_module.html#parameter-timeout
