### PR TITLE
Update jenkins url key and move jenkins repository variables from var…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,11 @@ jenkins_repo_archive_url: "https://get.jenkins.io/debian/"
 jenkins_repo_archive_package_prefix: jenkins  # hudson or jenkins
 jenkins_repo_archive_package: "{{ jenkins_repo_archive_package_prefix }}_{{ jenkins_version }}_all.deb"
 
+# Jenkins repository
+jenkins_repo_base_url: "https://pkg.jenkins.io/debian-stable"
+jenkins_repo_key_url: "{{ jenkins_repo_base_url }}/jenkins.io-2023.key"
+jenkins_repo_url: "deb {{ jenkins_repo_base_url }}/ binary/"
+
 ## Service options
 # Owner
 jenkins_user: jenkins

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,12 +11,6 @@ jenkins_required_libs:
   - python-lxml
   - fontconfig
 
-
-# Package
-jenkins_repo_base_url: "https://pkg.jenkins.io/debian-stable"
-jenkins_repo_key_url: "{{ jenkins_repo_base_url }}/jenkins.io.key"
-jenkins_repo_url: "deb {{ jenkins_repo_base_url }}/ binary/"
-
 # URLs
 jenkins_url: "http://{{ jenkins_host }}:{{ jenkins_port }}"
 jenkins_plugins_update_url: https://updates.jenkins.io/update-center.json


### PR DESCRIPTION
### Requirements
No new functionalities have been added. Only the value of the "jenkins_repo_key_url" variable has been updated, and the variables related to the Jenkins repository have been moved to "defaults/main.yml" (see "Benefits").
The requirements and tests that are already implemented should continue to work.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
The signing key of the Jenkins repository has changed (https://www.jenkins.io/blog/2023/03/27/repository-signing-keys-changing/). So, if we try to provision our machine with "jenkins_role" we have an error similar to:
![264631440-829dea02-81b1-46e4-8fcd-c1ec45fcb9e2](https://github.com/idealista/jenkins_role/assets/33899311/2c046d3f-b39f-4280-956e-1c51178458cd)

The proposal is to replace the line:

https://github.com/idealista/jenkins_role/blob/c241324b9bd47c6ff964fe68307b492977037b22/vars/main.yml#L17

to:

`jenkins_repo_key_url: "{{ jenkins_repo_base_url }}/jenkins.io-2023.key"`

Another suggestion is to move Jenkins repository variables:

- jenkins_repo_base_url
- jenkins_repo_key_url
- jenkins_repo_url

from "vars/main.yml" to "defaults/main.yml" so that they can be overwritten from our playbook in "group_vars/*", similar to "Jenkins package" variables.

### Benefits

<!-- What benefits will be realized by the code change? -->
- Install Jenkins without errors.
- Group Jenkins repository variables in "defaults/main.yml" to let overwrite them from our playbook.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

[Update jenkins signing key](https://github.com/idealista/jenkins_role/issues/81)